### PR TITLE
Add default page parameter to getProducts() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const UNKNOWN_ERROR = 'There was an unknown error. Please contact our customer s
 
 export default {
   ...RNShopify,
-  getProducts: (page, collectionId, tags) => {
+  getProducts: (page = 1, collectionId, tags) => {
     if (collectionId) {
       return RNShopify.getProductsWithTagsForCollection(page, collectionId, tags);
     }


### PR DESCRIPTION
The Readme states that you can do `Shopify.getProducts()`, but it actually doesn't work until you provide a page number. This PR just adds a default parameter to `1` on `getProducts()` method