### PR TITLE
Fix 'requiresMainQueueSetup' warning.

### DIFF
--- a/ios/RNShopify.m
+++ b/ios/RNShopify.m
@@ -6,6 +6,11 @@
     RCTPromiseRejectBlock _reject;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-shopify",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "React Native bridge for Shopify Mobile Buy SDK for iOS and Android",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes `console.warn` triggered by `init` being overwritten but `requiresMainQueueSetup` not being set.